### PR TITLE
chore: restore codecov upload, bump toolkit 6.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "1.82"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 workflows:
   validation:
@@ -66,7 +66,6 @@ workflows:
                 - main
       - toolkit/code_coverage:
           package: nextsv
-          codecov: false
           filters:
             branches:
               ignore:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -15,7 +15,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 workflows:
   update_prlog:


### PR DESCRIPTION
## Summary

Re-enables the `code_coverage` Codecov upload that was temporarily disabled (`codecov: false`) to work around the org-wide Codecov uploader failure (so the git2 fix could land), and bumps `jerus-org/circleci-toolkit@6.2.0 → 6.3.0` across all three pipeline files.

## Why now

6.3.0 ships **codecov orb 6.0.0**, which fixes the `gpg: no valid OpenPGP data found` upload failure. With that resolved, the workaround is no longer needed.

## Changes

- `config.yml`: drop `codecov: false` from the `toolkit/code_coverage` invocation (the job defaults `codecov: true`), restoring upload.
- `config.yml`, `release.yml`, `update_prlog.yml`: `circleci-toolkit@6.2.0 → 6.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)